### PR TITLE
Add support to ignored paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,14 @@ If no locations are given default location is:
 * current directory if plugin is run outside Leiningen project
 
 
+### Ignoring files
+
+You can ignore a specific file or directory by excluding it from command-line:
+
+```
+lein nsorg --exclude src/my-project/broken_file.clj --exclude test
+```
+
 ### Apply changes automatically
 
 By default lein-nsorg prints diffs for suggested changes. Changes can be applied automatically to source files with the

--- a/test/leiningen/nsorg_tests.clj
+++ b/test/leiningen/nsorg_tests.clj
@@ -33,8 +33,7 @@
     (= expected-file-path (.getPath file))))
 
 (fact
-  "Finds Clojure files recursively"
-  (nsorg/find-clojure-files ["test_files"]) => (just [(file-matcher "test_files/core.clj")
-                                                      (file-matcher "test_files/core.cljc")
-                                                      (file-matcher "test_files/core.cljs")
-                                                      (file-matcher "test_files/foo/bar.cljc")]))
+  "Finds Clojure files recursively. Ignore files in ignored-paths."
+  (nsorg/find-clojure-files ["test_files"] ["test_files/foo/bar.cljc"]) => (just [(file-matcher "test_files/core.clj")
+                                                                                  (file-matcher "test_files/core.cljc")
+                                                                                  (file-matcher "test_files/core.cljs")]))


### PR DESCRIPTION
This option allow you to configure an new options in the `project.clj` file, excluding some files from nsorg. For example, running it as:

```clojure
{:nsorg
  {:ignore-files ["test/leiningen/nsorg/broken_test.clj"]}}
```

Will explicitly ignore `test/leiningen/nsorg/broken_test.clj` from nsorg.